### PR TITLE
Create RemoteOutput func

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@
 // uses golang's native ssh client. It has also been improved to resize the tty
 // accordingly.  The key functions are meant to be used by either client or server
 // and will generate/store keys if not found.
-package main
+package ssh
 
 import (
 	"bytes"

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func wrapError(err error) error {
 
 // Client is a relic interface that both native and external client matched
 type Client interface {
-	// Output returns the output of the command run on the remote host.
+	// Output returns the output of the command run on the host.
 	Output(command string) (string, error)
 
 	// Shell requests a shell from the remote. If an arg is passed, it tries to
@@ -91,6 +91,9 @@ type Client interface {
 	// Wait waits for the command started by the Start function to exit. The
 	// returned error follows the same logic as in the exec.Cmd.Wait function.
 	Wait() error
+
+	// RemoteOutput returns the output of the command run on the remote host
+	RemoteOutput(remoteHost, command string) (string, error)
 }
 
 // NativeClient is the structure for native client use

--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -175,9 +176,8 @@ func NewNativeClient(user, host, clientVersion string, port int, proxyHost strin
 
 	key := ""
 	if len(hostAuth.Keys) == 1 {
-		key = hostAuth.Keys[0]
+		key = filepath.Base(hostAuth.Keys[0])
 	}
-
 	return &NativeClient{
 		HostConfig:    hostConfig,
 		ProxyConfig:   proxyConfig,
@@ -319,7 +319,7 @@ func (client *NativeClient) Session() (*ssh.Session, *ssh.Client, *ssh.Client, e
 	return session, proxy, conn, nil
 }
 
-//RemoteOutput returns the of the command run proxied through the host the remote host. The same credentials and timeout are used
+//RemoteOutput returns the of the command run proxied through the host the remote host. The same credentials and timeout are used.  The remote key must be in the home directory
 func (client *NativeClient) RemoteOutput(remoteHost, command string) (string, error) {
 	timeout := fmt.Sprintf("ConnectTimeout=%v", client.HostConfig.Timeout.Seconds())
 	sshCmd := fmt.Sprintf("ssh -o %s -o %s -o %s -o %s -i %s %s@%s \"%s\"", SSHOpts[0], SSHOpts[1], SSHOpts[2], timeout, client.RemoteKey, client.HostConfig.User, remoteHost, command)

--- a/client.go
+++ b/client.go
@@ -275,7 +275,6 @@ func (nclient *NativeClient) Connect() (*ssh.Client, error) {
 				return nil, fmt.Errorf("ssh dial fail to %s - %v", destAddr, err)
 			}
 			conn, err = sshClient.Dial("tcp", destAddr)
-			fmt.Printf("Conn open %v\n", conn)
 			if err != nil {
 				return nil, fmt.Errorf("ssh client dial fail to %s - %v", destAddr, err)
 			}
@@ -286,12 +285,10 @@ func (nclient *NativeClient) Connect() (*ssh.Client, error) {
 			if err != nil {
 				return nil, fmt.Errorf("ssh dial fail to %s", destAddr)
 			}
-			fmt.Printf("Conn open %v\n", conn)
 			sshconn, chans, reqs, err := ssh.NewClientConn(conn, h.HostName, h.ClientConfig)
 			if err != nil {
 				return nil, fmt.Errorf("NewClientConn fail to %s", destAddr)
 			}
-			fmt.Printf("Conn open %v\n", sshconn)
 			sshClient = ssh.NewClient(sshconn, chans, reqs)
 			nclient.openClients = append(nclient.openClients, sshClient)
 			nclient.openConns = append(nclient.openConns, conn)
@@ -488,47 +485,4 @@ func termSize(fd uintptr) []byte {
 	binary.BigEndian.PutUint32(size[4:], uint32(winsize.Height))
 
 	return size
-}
-
-func main() {
-	timeout := time.Second * 10
-	key := "/Users/jimmorris/.mobiledgex/id_rsa_mex"
-	auth := Auth{Keys: []string{key}}
-
-	vers := "SSH-2.0-mobiledgex-ssh-client-1.0"
-
-	pass := 0
-	fail := 0
-	//func NewNativeClient(user, clientVersion string, host string, port int, hostAuth *Auth, timeout time.Duration, hostKeyCallback ssh.HostKeyCallback) (Client, error) {
-
-	for i := 1; i < 100; i++ {
-		fmt.Printf("\nLOOP %d pass: %d fail %d\n", i, pass, fail)
-		client, err := NewNativeClient("ubuntu", vers, "80.187.128.15", 22, &auth, timeout, nil)
-		//client.AddHop("10.101.2.10", 22)
-		//	client.AddHop("10.101.2.10", 22)
-		client.AddHop("80.187.128.15", 22)
-		client.AddHop("10.101.2.101", 22)
-		client.AddHop("10.101.2.10", 22)
-
-		/*client.RemoveLastHop()
-		client.RemoveLastHop()
-		client.RemoveLastHop()
-		err = client.RemoveLastHop()
-		err = client.RemoveLastHop()*/
-
-		if err != nil {
-			fmt.Printf("NewClient ERR %v\n", err)
-			fail++
-			continue
-		}
-
-		out, err := client.Output("hostname")
-		fmt.Printf("OUT %s err %v\n", out, err)
-		if err != nil {
-			fail++
-		} else {
-			pass++
-		}
-	}
-
 }

--- a/client.go
+++ b/client.go
@@ -459,7 +459,7 @@ func (client *NativeClient) Shell(sin io.Reader, sout, serr io.Writer, args ...s
 		}
 
 		// monitor for sigwinch
-		//go monWinCh(session, os.Stdout.Fd())
+		go monWinCh(session, os.Stdout.Fd())
 
 		session.Wait()
 	} else {


### PR DESCRIPTION
Implements RemoteOutput.  This will be used for to allow the client to perform commands on a server one hop away from the client.   It will replace ssh proxy commands within edge-cloud-infra and allow docker code in edge-cloud to run commands remotely.

Also add a timeout option to the configuration.