### PR TITLE
Refactor for multiple SSH hops

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@
 // uses golang's native ssh client. It has also been improved to resize the tty
 // accordingly.  The key functions are meant to be used by either client or server
 // and will generate/store keys if not found.
-package main
+package ssh
 
 import (
 	"bytes"

--- a/client.go
+++ b/client.go
@@ -346,12 +346,16 @@ func (nclient *NativeClient) Connect() (*ssh.Client, *SessionInfo, error) {
 			select {
 			case result := <-ch:
 				if result != "" {
-					conn.Close()
+					if conn != nil {
+						conn.Close()
+					}
 					sessionInfo.CloseAll()
 					return nil, nil, fmt.Errorf(result)
 				}
 			case <-time.After(h.ClientConfig.Timeout):
-				conn.Close()
+				if conn != nil {
+					conn.Close()
+				}
 				sessionInfo.CloseAll()
 				return nil, nil, fmt.Errorf("ssh client timeout to %s", destAddr)
 			}

--- a/client.go
+++ b/client.go
@@ -278,7 +278,6 @@ func (nclient *NativeClient) Connect() (*ssh.Client, error) {
 
 	for _, h := range nclient.HostDetails {
 		destAddr = fmt.Sprintf("%s:%d", h.HostName, h.Port)
-		fmt.Printf("DESTADDR %s\n", destAddr)
 		if sshClient == nil {
 			//first host
 			sshClient, err = ssh.Dial("tcp", destAddr, h.ClientConfig)

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func wrapError(err error) error {
 
 // Client is a relic interface that both native and external client matched
 type Client interface {
-	// Output returns the output of the command run on the remote host.
+	// Output returns the output of the command run on the host.
 	Output(command string) (string, error)
 
 	// Shell requests a shell from the remote. If an arg is passed, it tries to
@@ -91,6 +91,9 @@ type Client interface {
 	// Wait waits for the command started by the Start function to exit. The
 	// returned error follows the same logic as in the exec.Cmd.Wait function.
 	Wait() error
+
+	// RemoteOutput returns the output of the command run on the remote host
+	RemoteOutput(remoteHost, command string) (string, error)
 }
 
 // NativeClient is the structure for native client use

--- a/client.go
+++ b/client.go
@@ -87,6 +87,8 @@ type Client interface {
 	// Wait waits for the command started by the Start function to exit. The
 	// returned error follows the same logic as in the exec.Cmd.Wait function.
 	Wait() error
+	// AddHpp adds a new host to the end of the list
+	AddHop(host string, port int) error
 }
 
 type HostDetail struct {

--- a/client.go
+++ b/client.go
@@ -90,7 +90,7 @@ type Client interface {
 	Wait() error
 	// AddHop adds a new host to the end of the list and returns a new client.
 	// The original client is unchanged.
-	AddHop(host string, port int) (interface{}, error)
+	AddHop(host string, port int) (Client, error)
 }
 
 type HostDetail struct {
@@ -216,7 +216,7 @@ func (c *NativeClient) Copy() *NativeClient {
 
 // AddHopWithConfig adds a new host to the end of the list and returns a new client using the provided config
 // The original client is unchanged
-func (c *NativeClient) AddHopWithConfig(host string, port int, config *ssh.ClientConfig) (interface{}, error) {
+func (c *NativeClient) AddHopWithConfig(host string, port int, config *ssh.ClientConfig) (Client, error) {
 	newClient := c.Copy()
 	var hostDetail = HostDetail{HostName: host, Port: port, ClientConfig: config}
 	newClient.HostDetails = append(newClient.HostDetails, hostDetail)
@@ -225,7 +225,7 @@ func (c *NativeClient) AddHopWithConfig(host string, port int, config *ssh.Clien
 
 // AddHop adds a new host to the end of the list and returns a new client using the same config
 // The original client is unchanged
-func (c *NativeClient) AddHop(host string, port int) (interface{}, error) {
+func (c *NativeClient) AddHop(host string, port int) (Client, error) {
 	return c.AddHopWithConfig(host, port, c.DefaultClientConfig)
 }
 

--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -175,9 +176,8 @@ func NewNativeClient(user, host, clientVersion string, port int, proxyHost strin
 
 	key := ""
 	if len(hostAuth.Keys) == 1 {
-		key = hostAuth.Keys[0]
+		key = filepath.Base(hostAuth.Keys[0])
 	}
-
 	return &NativeClient{
 		HostConfig:    hostConfig,
 		ProxyConfig:   proxyConfig,
@@ -319,7 +319,7 @@ func (client *NativeClient) Session() (*ssh.Session, *ssh.Client, *ssh.Client, e
 	return session, proxy, conn, nil
 }
 
-//RemoteOutput returns the of the command run proxied through the host the remote host. The same credentials and timeout are used
+//RemoteOutput returns the of the command run proxied through the host the remote host. The same credentials and timeout are used.  The remote key must be in the home directory
 func (client *NativeClient) RemoteOutput(remoteHost, command string) (string, error) {
 	timeout := fmt.Sprintf("ConnectTimeout=%v", client.HostConfig.Timeout.Seconds())
 	sshCmd := fmt.Sprintf("ssh -o %s -o %s -o %s -o %s -i %s %s@%s \"%s\"", SSHOpts[0], SSHOpts[1], SSHOpts[2], timeout, client.RemoteKey, client.HostConfig.User, remoteHost, command)

--- a/client.go
+++ b/client.go
@@ -275,7 +275,6 @@ func (nclient *NativeClient) Connect() (*ssh.Client, error) {
 				return nil, fmt.Errorf("ssh dial fail to %s - %v", destAddr, err)
 			}
 			conn, err = sshClient.Dial("tcp", destAddr)
-			fmt.Printf("Conn open %v\n", conn)
 			if err != nil {
 				return nil, fmt.Errorf("ssh client dial fail to %s - %v", destAddr, err)
 			}
@@ -286,12 +285,10 @@ func (nclient *NativeClient) Connect() (*ssh.Client, error) {
 			if err != nil {
 				return nil, fmt.Errorf("ssh dial fail to %s", destAddr)
 			}
-			fmt.Printf("Conn open %v\n", conn)
 			sshconn, chans, reqs, err := ssh.NewClientConn(conn, h.HostName, h.ClientConfig)
 			if err != nil {
 				return nil, fmt.Errorf("NewClientConn fail to %s", destAddr)
 			}
-			fmt.Printf("Conn open %v\n", sshconn)
 			sshClient = ssh.NewClient(sshconn, chans, reqs)
 			nclient.openClients = append(nclient.openClients, sshClient)
 			nclient.openConns = append(nclient.openConns, conn)
@@ -488,47 +485,4 @@ func termSize(fd uintptr) []byte {
 	binary.BigEndian.PutUint32(size[4:], uint32(winsize.Height))
 
 	return size
-}
-
-func main() {
-	timeout := time.Second * 10
-	key := "/Users/jimmorris/.mobiledgex/id_rsa_mex"
-	auth := Auth{Keys: []string{key}}
-
-	vers := "SSH-2.0-mobiledgex-ssh-client-1.0"
-
-	pass := 0
-	fail := 0
-	//func NewNativeClient(user, clientVersion string, host string, port int, hostAuth *Auth, timeout time.Duration, hostKeyCallback ssh.HostKeyCallback) (Client, error) {
-
-	for i := 1; i < 100; i++ {
-		fmt.Printf("\nLOOP %d pass: %d fail %d\n", i, pass, fail)
-		client, err := NewNativeClient("ubuntu", vers, "80.187.128.15", 22, &auth, timeout, nil)
-		//client.AddHop("10.101.2.10", 22)
-		//	client.AddHop("10.101.2.10", 22)
-		client.AddHop("80.187.128.15", 22)
-		client.AddHop("10.101.2.101", 22)
-		client.AddHop("10.101.2.10", 22)
-
-		/*client.RemoveLastHop()
-		client.RemoveLastHop()
-		client.RemoveLastHop()
-		err = client.RemoveLastHop()
-		err = client.RemoveLastHop()*/
-
-		if err != nil {
-			fmt.Printf("NewClient ERR %v\n", err)
-			fail++
-			continue
-		}
-
-		out, err := client.Output("hostname")
-		fmt.Printf("OUT %s err %v\n", out, err)
-		if err != nil {
-			fail++
-		} else {
-			pass++
-		}
-	}
-
 }

--- a/client.go
+++ b/client.go
@@ -459,7 +459,7 @@ func (client *NativeClient) Shell(sin io.Reader, sout, serr io.Writer, args ...s
 		}
 
 		// monitor for sigwinch
-		//go monWinCh(session, os.Stdout.Fd())
+		go monWinCh(session, os.Stdout.Fd())
 
 		session.Wait()
 	} else {

--- a/client.go
+++ b/client.go
@@ -89,8 +89,8 @@ type Client interface {
 	// returned error follows the same logic as in the exec.Cmd.Wait function.
 	Wait() error
 	// AddHop adds a new host to the end of the list and returns a new client.
-	// The original client is unchanged
-	AddHop(host string, port int) (Client, error)
+	// The original client is unchanged.
+	AddHop(host string, port int) (interface{}, error)
 }
 
 type HostDetail struct {
@@ -216,7 +216,7 @@ func (c *NativeClient) Copy() *NativeClient {
 
 // AddHopWithConfig adds a new host to the end of the list and returns a new client using the provided config
 // The original client is unchanged
-func (c *NativeClient) AddHopWithConfig(host string, port int, config *ssh.ClientConfig) (Client, error) {
+func (c *NativeClient) AddHopWithConfig(host string, port int, config *ssh.ClientConfig) (interface{}, error) {
 	newClient := c.Copy()
 	var hostDetail = HostDetail{HostName: host, Port: port, ClientConfig: config}
 	newClient.HostDetails = append(newClient.HostDetails, hostDetail)
@@ -225,12 +225,12 @@ func (c *NativeClient) AddHopWithConfig(host string, port int, config *ssh.Clien
 
 // AddHop adds a new host to the end of the list and returns a new client using the same config
 // The original client is unchanged
-func (c *NativeClient) AddHop(host string, port int) (Client, error) {
+func (c *NativeClient) AddHop(host string, port int) (interface{}, error) {
 	return c.AddHopWithConfig(host, port, c.DefaultClientConfig)
 }
 
 // RemoveLastHop returns a new client which is a copy of the original with the last hop removed
-func (c *NativeClient) RemoveLastHop() (Client, error) {
+func (c *NativeClient) RemoveLastHop() (interface{}, error) {
 	if len(c.HostDetails) < 1 {
 		return nil, fmt.Errorf("no hops to remove")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -18,7 +18,7 @@ var vers string
 // this data is subject to change; it needs to be populated with 2 working servers
 // that can reach each other via the key provided
 func initTestData() {
-	testServers = []string{"35.199.188.102", "35.199.188.102", "37.50.200.27"} // twice thru the first svr and then to another
+	testServers = []string{"35.199.188.102", "35.199.188.102", "80.187.128.13"} // twice thru the first svr and then to another
 	key = os.Getenv("HOME") + "/.mobiledgex/id_rsa_mex"
 	timeout = time.Second * 10
 	vers = "SSH-2.0-mobiledgex-ssh-client-1.0"

--- a/client_test.go
+++ b/client_test.go
@@ -62,8 +62,7 @@ func TestNativeClient(t *testing.T) {
 
 	//now add bad hop and check for error
 	badClient, _ := client.AddHop("10.10.10.10", 22)
-	client = badClient.(Client)
-	_, err = client.Output("echo hello")
+	_, err = badClient.Output("echo hello")
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "ssh client timeout")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -41,9 +41,9 @@ func TestNativeClient(t *testing.T) {
 	results := make(chan Result, numThread)
 
 	for hopTest := 0; hopTest < len(testServers); hopTest++ {
-		var err error
 		if hopTest != 0 {
-			client, err = client.AddHop(testServers[hopTest], 22)
+			newclient, err := client.AddHop(testServers[hopTest], 22)
+			client = newclient.(Client)
 			require.Nil(t, err, "addhop")
 		}
 		for i := 0; i < numThread; i++ {
@@ -62,7 +62,8 @@ func TestNativeClient(t *testing.T) {
 
 	//now add bad hop and check for error
 	badClient, _ := client.AddHop("10.10.10.10", 22)
-	_, err = badClient.Output("echo hello")
+	client = badClient.(Client)
+	_, err = client.Output("echo hello")
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "ssh client timeout")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,67 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// these servers need to be modified when running to have working SSH servers
+var testServers []string
+var key string
+var timeout time.Duration
+var vers string
+
+// this data is subject to change; it needs to be populated with 2 working servers
+// that can reach each other via the key provided
+func initTestData() {
+	testServers = []string{"35.199.188.102", "35.199.188.102", "37.50.200.27"} // twice thru the first svr and then to another
+	key = os.Getenv("HOME") + "/.mobiledgex/id_rsa_mex"
+	timeout = time.Second * 10
+	vers = "SSH-2.0-mobiledgex-ssh-client-1.0"
+}
+
+type Result struct {
+	expected string
+	out      string
+	err      error
+}
+
+func TestNativeClient(t *testing.T) {
+	initTestData()
+	auth := Auth{Keys: []string{key}}
+	client, err := NewNativeClient("ubuntu", vers, testServers[0], 22, &auth, timeout, nil)
+	//client.AddHop(testServers[1])
+	require.Nil(t, err, "NewNativeClient")
+	// run 3 tests concurrently 4 times
+	numThread := 5
+	results := make(chan Result, numThread)
+
+	for hopTest := 0; hopTest < len(testServers); hopTest++ {
+		if hopTest != 0 {
+			err := client.AddHop(testServers[hopTest], 22)
+			require.Nil(t, err, "addhop")
+		}
+		for i := 0; i < numThread; i++ {
+			go func() {
+				expected := fmt.Sprintf("testing: %d", i)
+				out, err := client.Output("echo " + expected)
+				results <- Result{expected, out, err}
+			}()
+		}
+		for i := 0; i < numThread; i++ {
+			result := <-results
+			require.Nil(t, result.err, "result")
+			require.Equal(t, result.expected, result.out, result.expected)
+		}
+	}
+
+	// now add bad hop and check for error
+	client.AddHop("10.10.10.10", 22)
+	_, err = client.Output("hello")
+	require.Contains(t, err.Error(), "ssh client timeout")
+
+}

--- a/client_test.go
+++ b/client_test.go
@@ -41,8 +41,9 @@ func TestNativeClient(t *testing.T) {
 	results := make(chan Result, numThread)
 
 	for hopTest := 0; hopTest < len(testServers); hopTest++ {
+		var err error
 		if hopTest != 0 {
-			err := client.AddHop(testServers[hopTest], 22)
+			client, err = client.AddHop(testServers[hopTest], 22)
 			require.Nil(t, err, "addhop")
 		}
 		for i := 0; i < numThread; i++ {
@@ -59,9 +60,9 @@ func TestNativeClient(t *testing.T) {
 		}
 	}
 
-	// now add bad hop and check for error
-	client.AddHop("10.10.10.10", 22)
-	_, err = client.Output("hello")
+	//now add bad hop and check for error
+	badClient, _ := client.AddHop("10.10.10.10", 22)
+	_, err = badClient.Output("echo hello")
+	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "ssh client timeout")
-
 }


### PR DESCRIPTION
Based on previous review of remote output changes:

We now use the cliently directly to run commands on a remote hop instead of via ssh bash commands .  An unlimited number of hops are now supported (but not currently for Shell which we don't use anyway).

This required a bit of refactoring.  It also complicated the cleanup because there can be many connections created which are not used by the caller but have to be cleaned up. These are saved into a new struct SessionInfo.  While in most cases, a given sessionInfo is used by only one thread, there's a chance in future someone could call Start/Wait

Created unit tests with some multithreaded tests.