### PR TITLE
Multi-hop support for Shell

### DIFF
--- a/client.go
+++ b/client.go
@@ -494,19 +494,12 @@ func (client *NativeClient) Shell(sin io.Reader, sout, serr io.Writer, args ...s
 	var (
 		termWidth, termHeight = 80, 24
 	)
-	if len(client.HostDetails) == 0 {
-		return fmt.Errorf("no hops available")
-	}
-	conn, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", client.HostDetails[0].HostName, client.HostDetails[0].Port), client.HostDetails[0].ClientConfig)
+	session, sessionInfo, err := client.Session(client.DefaultClientConfig.Timeout)
+	// even on failure, intermediate hop connections must close
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
-
-	session, err := conn.NewSession()
-	if err != nil {
-		return err
-	}
+	defer sessionInfo.CloseAll()
 	defer session.Close()
 
 	session.Stdout = sout

--- a/client_test.go
+++ b/client_test.go
@@ -51,11 +51,11 @@ func TestNativeClient(t *testing.T) {
 			require.Nil(t, err, "addhop")
 		}
 		for i := 0; i < numThread; i++ {
-			go func() {
+			go func(i int) {
 				expected := fmt.Sprintf("testing: %d", i)
 				out, err := client.Output("echo " + expected)
 				results <- Result{expected, out, err}
-			}()
+			}(i)
 		}
 		for i := 0; i < numThread; i++ {
 			result := <-results


### PR DESCRIPTION
* Use `client.Session` to fetch session, as `client.Session` already handles multi-hop session
* Once approved will tag a release and make changes in edge-cloud repo to pull in this new release